### PR TITLE
fix(useNativeLazyLoading): incorrect "useInView" import

### DIFF
--- a/packages/useNativeLazyLoading/readme.md
+++ b/packages/useNativeLazyLoading/readme.md
@@ -25,7 +25,7 @@ Example of how to combine this with `react-intersction-observer`, to create a la
 ```js
 import React from 'react'
 import useNativeLazyLoading from '@charlietango/use-native-lazy-loading'
-import useInView from 'react-intersection-observer'
+import { useInView } from 'react-intersection-observer'
 
 const LazyImage = ({ width, height, src, ...rest }) => {
   const supportsLazyLoading = useNativeLazyLoading()


### PR DESCRIPTION
The available sample imports `useInView` as if it was the default export from `react-intersection-observer` package. This commit fixes this small mistake, as `useInView` is **not** the default export.